### PR TITLE
Add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.2",
   "description": "gulp plugin for unzip",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/suisho/gulp-unzip.git"
+  },
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
Running gulp-unzip will result in the following warning:
`npm WARN package.json gulp-unzip@0.1.2 No repository field.`

Adding the missing repository field fixes this.